### PR TITLE
ENH: This adds the export method and serializer class, tests are coming

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+branch = true
+include = suitcase/tiff/*
+omit = suitcase/tiff/_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - pip install -r requirements-dev.txt
 
 script:
-  - coverage run -m pytest suitcase/tiff/tests.py  # Run the tests and check for test coverage.
-  - coverage report -m  --include=suitcase/*  # Generate test coverage report.
+  - coverage run -m pytest  # Run the tests and check for test coverage.
+  - coverage report -m  # Generate test coverage report.
   - codecov  # Upload the report to codecov.
   - flake8 --max-line-length=115  # Enforce code style (but relax line length limit a bit).
   - make -C docs html  # Build the documentation.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ install:
   - pip install -r requirements-dev.txt
 
 script:
-  - coverage run -m pytest  # Run the tests and check for test coverage.
-  - coverage report -m  # Generate test coverage report.
+  - coverage run -m pytest suitcase/tiff/tests.py  # Run the tests and check for test coverage.
+  - coverage report -m  --include=suitcase/*  # Generate test coverage report.
   - codecov  # Upload the report to codecov.
   - flake8 --max-line-length=115  # Enforce code style (but relax line length limit a bit).
   - make -C docs html  # Build the documentation.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = suitcase/tiff/
+python_files = test*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,13 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+bluesky
 codecov
+caproto  # required in order to import ophyd test fixtures
+curio  # required in order to import ophyd test fixtures
 coverage
 flake8
+# TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
+git+git://github.com/awalter-bnl/ophyd@add-configure
 pytest
 sphinx
 # These are dependencies of various sphinx extensions for documentation.
@@ -11,3 +16,4 @@ matplotlib
 numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
+trio  # required in order to import ophyd test fixtures

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ coverage
 flake8
 # TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
 git+git://github.com/awalter-bnl/ophyd@add-configure
-pytest
+pytest >=3.9
 sphinx
 # These are dependencies of various sphinx extensions for documentation.
 ipython

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
-attrs >=18.1.0
+attrs >=18.1.0  # required in order to import ophyd test fixtures
 bluesky
 codecov
 caproto  # required in order to import ophyd test fixtures

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # These are required for developing the package (running the tests, building
 # the documentation) but not necessarily required for _using_ it.
+attrs >=18.1.0
 bluesky
 codecov
 caproto  # required in order to import ophyd test fixtures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 # List required packages in this file, one per line.
+event-model >=1.8.0rc1
+suitcase-utils
+tifffile

--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -197,8 +197,6 @@ class Serializer(event_model.DocumentRouter):
         # format self._file_prefix
         self._templated_file_prefix = self._file_prefix.format(**doc)
 
-        return doc
-
     def descriptor(self, doc):
         '''Use `descriptor` doc to map stream_names to descriptor uid's.
 
@@ -213,8 +211,6 @@ class Serializer(event_model.DocumentRouter):
         # extract some useful info from the doc
         streamname = doc.get('name')
         self._streamnames[doc['uid']] = streamname
-
-        return doc
 
     def event_page(self, doc):
         '''Add event page document information to a ".tiff" file.
@@ -272,7 +268,6 @@ class Serializer(event_model.DocumentRouter):
                         tw = TiffWriter(f, bigtiff=True)
                         self._files[streamname][field+f'-{num}'] = tw
                         tw.save(img, *self._kwargs)
-        return doc
 
     def close(self):
         '''Close all of the files opened by this Serializer.

--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -1,25 +1,256 @@
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
-
-
 # Suitcase subpackages must follow strict naming and interface conventions. The
 # public API should include some subset of the following. Any functions not
 # implemented should be omitted, rather than included and made to raise
 # NotImplementError, so that a client importing this library can immediately
 # know which portions of the suitcase API it supports without calling any
 # functions.
-#
-# def export(...)
-#     ...
-#
-#
-# def ingest(...):
-#     ...
-#
-#
-# def reflect(...):
-#     ...
-#
-#
-# handlers = []
+from collections import defaultdict
+from pathlib import Path
+import tifffile
+import event_model
+import numpy
+import suitcase.utils
+from ._version import get_versions
+
+__version__ = get_versions()['version']
+del get_versions
+
+
+def export(gen, directory, file_prefix='{uid}-', **kwargs):
+    """
+    Export a stream of documents to TIFF stack(s).
+
+    This creates a file named:
+    ``<directory>/<file_prefix>{stream_name}-{field}.tiff``
+    for every Event stream and field that contains 2D 'image like' data.
+
+    .. warning::
+
+        This process explicitly ignores all data that is not 2D and does not
+        include any metadata in the output file.
+
+    .. note::
+
+        This can alternatively be used to write data to generic buffers rather
+        than creating files on disk. See the documentation for the
+        ``directory`` parameter below.
+
+    Parameters
+    ----------
+    gen : generator
+        xpected to yield ``(name, document)`` pairs
+
+    directory : string, Path or Manager.
+        For basic uses, this should be the path to the output directory given
+        as a string or Path object. Use an empty string ``''`` to place files
+        in the current working directory.
+
+        In advanced applications, this may direct the serialized output to a
+        memory buffer, network socket, or other writable buffer. It should be
+        an instance of ``suitcase.utils.MemoryBufferManager`` and
+        ``suitcase.utils.MultiFileManager`` or any object implementing that
+        inferface. See the suitcase documentation (LINK ONCE WRITTEN) for
+        details.
+
+    file_prefix : str, optional
+        The first part of the filename of the generated output files. This
+        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        which are populated from the RunStart document. The default value is
+        ``{uid}-`` which is guaranteed to be present and unique. A more
+        descriptive value depends on the application and is therefore left to
+        the user.
+
+    **kwargs : kwargs
+        kwargs to be passed to ``tifffile.TiffWriter.save``.
+
+    Returns
+    -------
+    dest : dict
+        dict mapping the 'labels' to lists of file names
+
+    Examples
+    --------
+
+    Generate files with unique-identifer names in the current directory.
+
+    >>> export(gen, '')
+
+    Generate files with more readable metadata in the file names.
+
+    >>> export(gen, '', '{plan_name}-{motors}-')
+
+    Include the experiment's start time formatted as YY-MM-DD_HH-MM.
+
+    >>> export(gen, '', '{time:%%Y-%%m-%%d_%%H:%%M}')
+
+    Place the files in a different directory, such as on a mounted USB stick.
+
+    >>> export(gen, '/path/to/my_usb_stick')
+    """
+    serializer = Serializer(directory, file_prefix, **kwargs)
+    try:
+        for item in gen:
+            serializer(*item)
+    finally:
+        serializer.close()
+
+    return serializer.artifacts
+
+
+class Serializer(event_model.DocumentRouter):
+    """
+    Serialize a stream of documents to TIFF stack(s).
+
+    This creates a file named:
+    ``<directory>/<file_prefix>{stream_name}-{field}.tiff``
+    for every Event stream and field that contains 2D 'image like' data.
+
+    .. warning::
+
+        This process explicitly ignores all data that is not 2D and does not
+        include any metadata in the output file.
+
+
+    .. note::
+
+        This can alternatively be used to write data to generic buffers rather
+        than creating files on disk. See the documentation for the
+        ``directory`` parameter below.
+
+    Parameters
+    ----------
+    gen : generator
+        xpected to yield ``(name, document)`` pairs
+
+    directory : string, Path or Manager.
+        For basic uses, this should be the path to the output directory given
+        as a string or Path object. Use an empty string ``''`` to place files
+        in the current working directory.
+
+        In advanced applications, this may direct the serialized output to a
+        memory buffer, network socket, or other writable buffer. It should be
+        an instance of ``suitcase.utils.MemoryBufferManager`` and
+        ``suitcase.utils.MultiFileManager`` or any object implementing that
+        inferface. See the suitcase documentation (LINK ONCE WRITTEN) for
+        details.
+
+    file_prefix : str, optional
+        The first part of the filename of the generated output files. This
+        string may include templates as in ``{proposal_id}-{sample_name}-``,
+        which are populated from the RunStart document. The default value is
+        ``{uid}-`` which is guaranteed to be present and unique. A more
+        descriptive value depends on the application and is therefore left to
+        the user.
+
+    **kwargs : kwargs
+        kwargs to be passed to ``tifffile.TiffWriter.save``.
+    """
+    def __init__(self, directory, file_prefix='{uid}-', **kwargs):
+
+        if isinstance(directory, (str, Path)):
+            self.manager = suitcase.utils.MultiFileManager(directory)
+        else:
+            self.manager = directory
+
+        self.artifacts = self.manager._artifacts
+        self._stream_names = {}  # maps stream_names to each descriptor uids
+        self._files = defaultdict(dict)  # maps stream_name to field/file dicts
+        self._filenames = {}  # map stream_name to file names of tiff files
+        self._file_prefix = file_prefix
+        self._templated_file_prefix = ''
+        self._kwargs = kwargs
+        self._start_found = False
+
+    def start(self, doc):
+        '''Extracts `start` document information for formatting file_prefix.
+
+        This method checks that only one `start` document is seen and formats
+        `file_prefix` based on the contents of the `start` document.
+
+        Parameters:
+        -----------
+        doc : dict
+            RunStart document
+        '''
+
+        # raise an error if this is the second `start` document seen.
+        if self._start_found:
+            raise RuntimeError(
+                "The serializer in suitcase.tiff expects documents from one "
+                "run only. Two `start` documents where sent to it")
+        else:
+            self._start_found = True
+
+        # format self._file_prefix
+        self._templated_file_prefix = self._file_prefix.format(**doc)
+
+        # return the start document
+        return doc
+
+    def descriptor(self, doc):
+        '''Use `descriptor` doc to map stream_names to descriptor uid's.
+
+        This method usess the descriptor document information to map the
+        stream_names to descriptor uid's.
+
+        Parameters:
+        -----------
+        doc : dict
+            EventDescriptor document
+        '''
+        # extract some useful info from the doc
+        stream_name = doc.get('name')
+        self._stream_names[doc['uid']] = stream_name
+
+        # return the descriptor doc
+        return doc
+
+    def event_page(self, doc):
+        '''Add event page document information to a ".tiff" file.
+
+        This method adds event_page document information to a ".tiff" file,
+        creating it if nesecary.
+
+        .. warning::
+
+            All non 2D 'image like' data is explicitly ignored.
+
+        .. note::
+
+            The data in Events might be structured as an Event, an EventPage,
+            or a "bulk event" (deprecated). The DocumentRouter base class takes
+            care of first transforming the other repsentations into an
+            EventPage and then routing them through here, so no further action
+            is required in this class. We can assume we will always receive an
+            EventPage.
+
+        Parameters:
+        -----------
+        doc : dict
+            EventPage document
+        '''
+        event_model.verify_filled(doc)
+        stream_name = self._stream_names[doc['descriptor']]
+        for field in doc['data']:
+            for img in doc['data'][field]:
+                # check that the data is 2D, if not ignore it
+                if numpy.asarray(img).ndim == 2:
+                    # create a file for this stream and field if none exists
+                    if not self._files.get(stream_name, {}).get(field):
+                        filename = f'{self._templated_file_prefix}' +\
+                            f'{stream_name}-{field}.tiff'
+                        f = self.manager.open('stream_data', filename, 'xb')
+                        self._files[stream_name][field] = tifffile.TiffWriter(
+                            f, bigtiff=True)
+                    # append the image to the file
+                    self._files[stream_name][field].save(img, *self._kwargs)
+
+        # return the event_page document
+        return doc
+
+    def close(self):
+        '''Close all of the files opened by this Serializer.
+        '''
+        for stream in self._files:
+            for file in self._files[stream].values():
+                file.close()

--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -87,7 +87,7 @@ def export(gen, directory, file_prefix='{uid}-', stack_images=True, **kwargs):
 
     Include the experiment's start time formatted as YY-MM-DD_HH-MM.
 
-    >>> export(gen, '', '{time:%%Y-%%m-%%d_%%H:%%M}')
+    >>> export(gen, '', '{time:%%Y-%%m-%%d_%%H:%%M}-')
 
     Place the files in a different directory, such as on a mounted USB stick.
 

--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -245,8 +245,8 @@ class Serializer(event_model.DocumentRouter):
                     if self._stack_images:
                         # create a file for this stream and field if required
                         if not self._files.get(streamname, {}).get(field):
-                            filename = f'{self._templated_file_prefix}'
-                            filename += f'{streamname}-{field}.tiff'
+                            filename = (f'{self._templated_file_prefix}'
+                                        f'{streamname}-{field}.tiff')
                             f = self.manager.open('stream_data', filename,
                                                   'xb')
                             self._files[streamname][field] = TiffWriter(
@@ -262,8 +262,8 @@ class Serializer(event_model.DocumentRouter):
                         else:
                             self._counter[streamname][field] += 1
                         num = self._counter[streamname][field]
-                        filename = f'{self._templated_file_prefix}'
-                        filename += f'{streamname}-{field}-{num}.tiff'
+                        filename = (f'{self._templated_file_prefix}'
+                                    f'{streamname}-{field}-{num}.tiff')
                         f = self.manager.open('stream_data', filename, 'xb')
                         tw = TiffWriter(f, bigtiff=True)
                         self._files[streamname][field+f'-{num}'] = tw

--- a/suitcase/tiff/conftest.py
+++ b/suitcase/tiff/conftest.py
@@ -1,4 +1,5 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
-from suitcase.utils.conftest import (example_data, generate_data, plan_type,
-				                     detector_list, event_type)  # noqa
+from suitcase.utils.tests.conftest import (example_data, generate_data,
+                                           plan_type, detector_list,
+                                           event_type)  # noqa

--- a/suitcase/tiff/conftest.py
+++ b/suitcase/tiff/conftest.py
@@ -1,5 +1,4 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
-from suitcase.utils.conftest import (events_data,
-				     detector_list,
-				     event_type)  # noqa
+from suitcase.utils.conftest import (example_data, generate_data, plan_type,
+				                     detector_list, event_type)  # noqa

--- a/suitcase/tiff/conftest.py
+++ b/suitcase/tiff/conftest.py
@@ -1,0 +1,5 @@
+from bluesky.tests.conftest import RE  # noqa
+from ophyd.tests.conftest import hw  # noqa
+from suitcase.utils.conftest import (events_data,
+				     detector_list,
+				     event_type)  # noqa

--- a/suitcase/tiff/conftest.py
+++ b/suitcase/tiff/conftest.py
@@ -1,5 +1,4 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
-from suitcase.utils.tests.conftest import (example_data, generate_data,
-                                           plan_type, detector_list,
-                                           event_type)  # noqa
+from suitcase.utils.tests.conftest import (  # noqa
+    example_data, generate_data, plan_type, detector_list, event_type)

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -2,7 +2,7 @@ from . import export
 import numpy
 from numpy.testing import assert_array_equal
 import pytest
-from suitcase.utils.conftest import (simple_plan,
+from suitcase.utils.tests.conftest import (simple_plan,
                                      multi_stream_one_descriptor_plan,
                                      one_stream_multi_descriptors_plan)
 import tifffile

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -11,8 +11,8 @@ expected = numpy.ones((10, 10))
 
 
 @pytest.mark.parametrize('plan', [simple_plan,
-                          multi_stream_one_descriptor_plan,
-                          one_stream_multi_descriptors_plan])
+                         multi_stream_one_descriptor_plan,
+                         one_stream_multi_descriptors_plan])
 @pytest.mark.parametrize('stack_images', [True, False])
 def test_export(plan, tmp_path, events_data, stack_images):
     ''' runs a test using the plan that is passed through to it

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -14,7 +14,7 @@ expected = numpy.ones((10, 10))
                           multi_stream_one_descriptor_plan,
                           one_stream_multi_descriptors_plan])
 @pytest.mark.parametrize('stack_images', [True, False])
-def test_run_plan(plan, tmp_path, events_data, stack_images):
+def test_export(plan, tmp_path, events_data, stack_images):
     ''' runs a test using the plan that is passed through to it
 
     ..note::

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -10,34 +10,11 @@ import tifffile
 expected = numpy.ones((10, 10))
 
 
-@pytest.fixture(params=[True, False], scope='function')
-def stack_images(request):
-    return request.param
-
-
-def test_simple_plan(tmp_path, events_data, stack_images):
-
-    ''' runs a test using a simple count plan with num=5
-    '''
-    run_plan_test(simple_plan, tmp_path, events_data, stack_images)
-
-
-def test_multi_stream_one_descriptor_plan(tmp_path, events_data, stack_images):
-    ''' runs a test using a simple count plan with num=5
-    '''
-    run_plan_test(multi_stream_one_descriptor_plan, tmp_path, events_data,
-                  stack_images)
-
-
-def test_one_stream_multi_descriptors_plan(tmp_path, events_data,
-                                           stack_images):
-    ''' runs a test using a simple count plan with num=5
-    '''
-    run_plan_test(one_stream_multi_descriptors_plan, tmp_path, events_data,
-                  stack_images)
-
-
-def run_plan_test(plan, tmp_path, events_data, stack_images):
+@pytest.mark.parametrize('plan', [simple_plan,
+                          multi_stream_one_descriptor_plan,
+                          one_stream_multi_descriptors_plan])
+@pytest.mark.parametrize('stack_images', [True, False])
+def test_run_plan(plan, tmp_path, events_data, stack_images):
     ''' runs a test using the plan that is passed through to it
 
     ..note::
@@ -48,7 +25,7 @@ def run_plan_test(plan, tmp_path, events_data, stack_images):
 
     '''
 
-    collector = events_data(simple_plan)
+    collector = events_data(plan)
     artifacts = export(collector, tmp_path, file_prefix='',
                        stack_images=stack_images)
 

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -22,7 +22,7 @@ def test_export(tmp_path, example_data, stack_images):
 
     '''
 
-    collector = example_data
+    collector = example_data()
     artifacts = export(collector, tmp_path, file_prefix='',
                        stack_images=stack_images)
 

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -10,11 +10,8 @@ import tifffile
 expected = numpy.ones((10, 10))
 
 
-@pytest.mark.parametrize('plan', [simple_plan,
-                         multi_stream_one_descriptor_plan,
-                         one_stream_multi_descriptors_plan])
 @pytest.mark.parametrize('stack_images', [True, False])
-def test_export(plan, tmp_path, events_data, stack_images):
+def test_export(tmp_path, example_data, stack_images):
     ''' runs a test using the plan that is passed through to it
 
     ..note::
@@ -25,7 +22,7 @@ def test_export(plan, tmp_path, events_data, stack_images):
 
     '''
 
-    collector = events_data(plan)
+    collector = example_data
     artifacts = export(collector, tmp_path, file_prefix='',
                        stack_images=stack_images)
 

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -13,20 +13,25 @@ def expected():
 
     return expected_array
 
+@pytest.fixture(params=[True, False], scope='function')
+def stack_images(request):
+    return request.param
 
-def test_simple_plan(events_data, expected):
+
+def test_simple_plan(events_data, expected, stack_images):
     ''' runs a test using a simple count plan with num=5
     '''
-    run_plan_test(simple_plan, events_data, expected)
+    run_plan_test(simple_plan, events_data, expected, stack_images)
 
 
-def test_multi_stream_one_descriptor_plan(events_data, expected):
+def test_multi_stream_one_descriptor_plan(events_data, expected, stack_images):
     ''' runs a test using a simple count plan with num=5
     '''
-    run_plan_test(multi_stream_one_descriptor_plan, events_data, expected)
+    run_plan_test(multi_stream_one_descriptor_plan, events_data, expected,
+                  stack_images)
 
 
-def run_plan_test(plan, events_data, expected):
+def run_plan_test(plan, events_data, expected, stack_images):
     ''' runs a test using the plan that is passed through to it
 
     ..note::
@@ -39,7 +44,8 @@ def run_plan_test(plan, events_data, expected):
 
     collector = events_data(simple_plan)
     directory = tempfile.mkdtemp()
-    artifacts = export(collector, directory, file_prefix='')
+    artifacts = export(collector, directory, file_prefix='',
+                       stack_images=stack_images)
 
     for filename in artifacts['stream_data']:
         # the following is required to convert from PosixPath to string

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -3,7 +3,8 @@ import numpy
 from numpy.testing import assert_array_equal
 import pytest
 from suitcase.utils.conftest import (simple_plan,
-                                     multi_stream_one_descriptor_plan)
+                                     multi_stream_one_descriptor_plan,
+                                     one_stream_multi_descriptors_plan)
 import tempfile
 import tifffile
 
@@ -28,6 +29,13 @@ def test_multi_stream_one_descriptor_plan(events_data, expected, stack_images):
     ''' runs a test using a simple count plan with num=5
     '''
     run_plan_test(multi_stream_one_descriptor_plan, events_data, expected,
+                  stack_images)
+
+
+def test_one_stream_multi_descriptors_plan(events_data, expected, stack_images):
+    ''' runs a test using a simple count plan with num=5
+    '''
+    run_plan_test(one_stream_multi_descriptors_plan, events_data, expected,
                   stack_images)
 
 

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -1,2 +1,53 @@
-# Tests should generate (and then clean up) any files they need for testing. No
-# binary files should be included in the repository.
+from . import export
+import numpy
+from numpy.testing import assert_array_equal
+import pytest
+from suitcase.utils.conftest import (simple_plan,
+                                     multi_stream_one_descriptor_plan)
+import tempfile
+import tifffile
+
+@pytest.fixture()
+def expected():
+    expected_array = numpy.ones((10, 10))
+
+    return expected_array
+
+
+def test_simple_plan(events_data, expected):
+    ''' runs a test using a simple count plan with num=5
+    '''
+    run_plan_test(simple_plan, events_data, expected)
+
+
+def test_multi_stream_one_descriptor_plan(events_data, expected):
+    ''' runs a test using a simple count plan with num=5
+    '''
+    run_plan_test(multi_stream_one_descriptor_plan, events_data, expected)
+
+
+def run_plan_test(plan, events_data, expected):
+    ''' runs a test using the plan that is passed through to it
+
+    ..note::
+
+        Due to the `events_data` `pytest.fixture` this will run multiple tests
+        each with a range of detectors and a range of event_types. see
+        `suitcase.utils.conftest` for more info
+
+    '''
+
+    collector = events_data(simple_plan)
+    directory = tempfile.mkdtemp()
+    artifacts = export(collector, directory, file_prefix='')
+
+    for filename in artifacts['stream_data']:
+        # the following is required to convert from PosixPath to string
+        if not type(filename) == str:
+             filename = str(filename)
+        actual = tifffile.imread(filename)
+        if len(actual.shape) == 3:
+            for img in actual:
+                assert_array_equal(img, expected)
+        else:
+            assert_array_equal(actual, expected)


### PR DESCRIPTION
This adds an export and a serilaizer method, based on the agreed assumption that this will explicitly ignore all non 2D data and the metadata.

This works manually, and I will add some test functions soon.

Closes #4