### PR TITLE
FIX: in testing dont rely on the loaded file to decide how many images it should contain

### DIFF
--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -2,6 +2,7 @@ from . import export
 import event_model
 import numpy
 from numpy.testing import assert_array_equal
+import os
 import pytest
 import tifffile
 
@@ -67,5 +68,5 @@ def test_export(tmp_path, example_data, stack_images):
 
     for filename in artifacts.get('stream_data', []):
         actual = tifffile.imread(str(filename))
-        streamname = str(filename).split('/')[-1].split('-')[0]
+        streamname = os.path.basename(filename).split('-')[0]
         assert_array_equal(actual, expected[streamname])

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -1,10 +1,50 @@
 from . import export
+import event_model
 import numpy
 from numpy.testing import assert_array_equal
 import pytest
 import tifffile
 
-expected = numpy.ones((10, 10))
+def create_expected(collector, stack_images):
+    streamnames = {}
+    events_dict = {}
+
+    for name, doc in collector:
+        if name == 'descriptor':
+            streamnames[doc['uid']] = doc.get('name')
+        elif name == 'event':
+            streamname = streamnames[doc['descriptor']]
+            if streamname not in events_dict.keys():
+                events_dict[streamname] = []
+            events_dict[streamname].append(doc)
+        elif name == 'bulk_events':
+            for key, events in doc.items():
+                for event in events:
+                    streamname = streamnames[event['descriptor']]
+                    if streamname not in events_dict.keys():
+                        events_dict[streamname] = []
+                    events_dict[streamname].append(event)
+        elif name == 'event_page':
+            for event in event_model.unpack_event_page(doc):
+                streamname = streamnames[event['descriptor']]
+                if streamname not in events_dict.keys():
+                    events_dict[streamname] = []
+                events_dict[streamname].append(event)
+
+        for stream_name, event_list in events_dict.items():
+            expected_dict = {}
+            if not stack_images:
+                expected_dict[stream_name] = numpy.ones((10,10))
+                expected_dict['baseline'] = numpy.ones((10,10))
+            elif len(event_list) == 1:
+                expected_dict[stream_name] = numpy.ones((10,10))
+                expected_dict['baseline'] = numpy.ones((2,10,10))
+            else:
+                expected_dict[stream_name] = numpy.ones(
+                    (len(event_list),10,10))
+                expected_dict['baseline'] = numpy.ones((3,10,10))
+
+    return expected_dict
 
 
 @pytest.mark.parametrize('stack_images', [True, False])
@@ -22,11 +62,10 @@ def test_export(tmp_path, example_data, stack_images):
     collector = example_data()
     artifacts = export(collector, tmp_path, file_prefix='',
                        stack_images=stack_images)
+    expected = create_expected(collector, stack_images)
+
 
     for filename in artifacts.get('stream_data', []):
         actual = tifffile.imread(str(filename))
-        if len(actual.shape) == 3:
-            for img in actual:
-                assert_array_equal(img, expected)
-        else:
-            assert_array_equal(actual, expected)
+        streamname = str(filename).split('/')[-1].split('-')[0]
+        assert_array_equal(actual, expected[streamname])

--- a/suitcase/tiff/tests.py
+++ b/suitcase/tiff/tests.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_array_equal
 import pytest
 import tifffile
 
+
 def create_expected(collector, stack_images):
     streamnames = {}
     events_dict = {}
@@ -34,15 +35,15 @@ def create_expected(collector, stack_images):
         for stream_name, event_list in events_dict.items():
             expected_dict = {}
             if not stack_images:
-                expected_dict[stream_name] = numpy.ones((10,10))
-                expected_dict['baseline'] = numpy.ones((10,10))
+                expected_dict[stream_name] = numpy.ones((10, 10))
+                expected_dict['baseline'] = numpy.ones((10, 10))
             elif len(event_list) == 1:
-                expected_dict[stream_name] = numpy.ones((10,10))
-                expected_dict['baseline'] = numpy.ones((2,10,10))
+                expected_dict[stream_name] = numpy.ones((10, 10))
+                expected_dict['baseline'] = numpy.ones((2, 10, 10))
             else:
                 expected_dict[stream_name] = numpy.ones(
-                    (len(event_list),10,10))
-                expected_dict['baseline'] = numpy.ones((3,10,10))
+                    (len(event_list), 10, 10))
+                expected_dict['baseline'] = numpy.ones((3, 10, 10))
 
     return expected_dict
 
@@ -63,7 +64,6 @@ def test_export(tmp_path, example_data, stack_images):
     artifacts = export(collector, tmp_path, file_prefix='',
                        stack_images=stack_images)
     expected = create_expected(collector, stack_images)
-
 
     for filename in artifacts.get('stream_data', []):
         actual = tifffile.imread(str(filename))


### PR DESCRIPTION
we found an fault in this that was not caught by the tests. Essentially the tests did not check how many images where saved into each file, this update fixes this and checks the input collector file for how many images should be contained in each file and compares this to the loaded files.