### PR TITLE
TST: added missing pytest dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,8 @@ flake8
 # TEMPORARY UNTIL https://github.com/NSLS-II/ophyd/pull/682 IS RELEASED
 git+git://github.com/awalter-bnl/ophyd@add-configure
 pytest >=3.9
+pytest_benchmark  # reported as missing by pytest
+asv  # reported as missing by pytest
 sphinx
 suitcase-utils[test_fixtures] >=0.1.0rc2
 # These are dependencies of various sphinx extensions for documentation.


### PR DESCRIPTION
There were a couple of notifications while I was trying to run pytest:
```
$ pytest
==================================================== test session starts ====================================================
platform darwin -- Python 3.6.7, pytest-3.9.3, py-1.7.0, pluggy-0.8.0
rootdir: /Users/mrakitin/src/mrakitin/DAMA/suitcase-tiff, inifile: pytest.ini
No module named 'pytest_benchmark' is missing
collected 54 items

suitcase/tiff/tests/tests.py ......................................................                                   [100%]
```

```
$ pytest
==================================================== test session starts ====================================================
platform darwin -- Python 3.6.7, pytest-3.9.3, py-1.7.0, pluggy-0.8.0
benchmark: 3.2.2 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/mrakitin/src/mrakitin/DAMA/suitcase-tiff, inifile: pytest.ini
plugins: benchmark-3.2.2
No module named 'asv' is missing
collected 54 items
```

I don't think it's harmful to not have these dependencies, but to make pytest happy this PR includes them.