### PR TITLE
PERF: Call asarray once and stash the result in a local.

### DIFF
--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -246,7 +246,8 @@ class Serializer(event_model.DocumentRouter):
         for field in doc['data']:
             for img in doc['data'][field]:
                 # check that the data is 2D, if not ignore it
-                if numpy.asarray(img).ndim == 2:
+                img_asarray = numpy.asarray(img)
+                if img_asarray.ndim == 2:
                     if self._stack_images:
                         # create a file for this stream and field if required
                         if not self._tiff_writers.get(streamname, {}).get(field):
@@ -258,7 +259,7 @@ class Serializer(event_model.DocumentRouter):
                             self._tiff_writers[streamname][field] = tw
                         # append the image to the file
                         tw = self._tiff_writers[streamname][field]
-                        tw.save(numpy.asarray(img), *self._kwargs)
+                        tw.save(img_asarray, *self._kwargs)
                     else:
                         if not (self._counter.get(streamname, {}).get(field) or
                                 self._counter.get(streamname, {}).get(field)
@@ -272,7 +273,7 @@ class Serializer(event_model.DocumentRouter):
                         file = self._manager.open('stream_data', filename, 'xb')
                         tw = TiffWriter(file, bigtiff=True)
                         self._tiff_writers[streamname][field+f'-{num}'] = tw
-                        tw.save(numpy.asarray(img), *self._kwargs)
+                        tw.save(img_asarray, *self._kwargs)
 
     def close(self):
         '''Close all of the files opened by this Serializer.


### PR DESCRIPTION
Performance optimization on #13 --- If ``numpy.asarray`` is making a copy (e.g.
from a Python ``list`` object) it would be faster to do it once.