### PR TITLE
ENH/REF: Allow Serializer and context.

### DIFF
--- a/suitcase/tiff/__init__.py
+++ b/suitcase/tiff/__init__.py
@@ -93,13 +93,10 @@ def export(gen, directory, file_prefix='{uid}-', stack_images=True, **kwargs):
 
     >>> export(gen, '/path/to/my_usb_stick')
     """
-    serializer = Serializer(directory, file_prefix,
-                            stack_images=stack_images, **kwargs)
-    try:
+    with Serializer(directory, file_prefix,
+                    stack_images=stack_images, **kwargs) as serializer:
         for item in gen:
             serializer(*item)
-    finally:
-        serializer.close()
 
     return serializer.artifacts
 
@@ -284,3 +281,9 @@ class Serializer(event_model.DocumentRouter):
         # Then let the manager (perhaps redundantly) close the underlying
         # files.
         self._manager.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exception_details):
+        self.close()


### PR DESCRIPTION
Is there a good reason *not* to do this? It introduces one more programming
concept that a Serializer *author* would need to use, but all they have to do
is copy/paste the ``__enter__`` and ``__exit__`` blocks as is, which doesn't
seem too bad.

On the plus side, it makes it easy to clean up correctly, and it matches the
semantics of ``open`` and ``*Manager.open``, which can be used as contexts.

If merged I will open similar PRs into the other suitcases, the documented
example in suitcase-core's docs, and the cookiecutter.