### PR TITLE
ENH: allows for formatting of the directory based on the start doc

### DIFF
--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -198,7 +198,7 @@ class Serializer(tiff_stack.Serializer):
                     self._templated_directory = self._directory.format(
                         start=doc)
                 except AttributeError:
-                    self._templated_directory= self._directory
+                    self._templated_directory = self._directory
                 self._manager = suitcase.utils.MultiFileManager(
                     self._templated_directory)
             else:

--- a/suitcase/tiff_series/__init__.py
+++ b/suitcase/tiff_series/__init__.py
@@ -194,7 +194,11 @@ class Serializer(tiff_stack.Serializer):
         else:
             self._start = doc  # record the start doc for later use
             if isinstance(self._directory, (str, Path)):
-                self._templated_directory = self._directory.format(start=doc)
+                try:  # if self._directory is a string
+                    self._templated_directory = self._directory.format(
+                        start=doc)
+                except AttributeError:
+                    self._templated_directory= self._directory
                 self._manager = suitcase.utils.MultiFileManager(
                     self._templated_directory)
             else:

--- a/suitcase/tiff_series/tests/conftest.py
+++ b/suitcase/tiff_series/tests/conftest.py
@@ -1,4 +1,5 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 from suitcase.utils.tests.conftest import (  # noqa
-    example_data, generate_data, plan_type, detector_list, event_type)
+    example_data, generate_data, plan_type, detector_list, event_type,
+    directory_list)

--- a/suitcase/tiff_series/tests/tests.py
+++ b/suitcase/tiff_series/tests/tests.py
@@ -117,7 +117,7 @@ def test_export(tmp_path, example_data):
 
 @pytest.mark.parametrize("directory", ['', '/test-', '/scan_{start[uid]}-'])
 def test_directory_formatting(directory, example_data, tmp_path):
-    ''' runs a test of the file_prefix formatting.
+    '''Runs a test of the file_prefix formatting.
 
     ..note::
 
@@ -133,6 +133,7 @@ def test_directory_formatting(directory, example_data, tmp_path):
     for name, doc in collector:
         if name == 'start':
             templated_directory = directory.format(start=doc).partition('-')[0]
+            break
 
     if artifacts:
         unique_actual = set(str(artifact).rsplit('/', 1)[0].partition('-')[0]

--- a/suitcase/tiff_series/tests/tests.py
+++ b/suitcase/tiff_series/tests/tests.py
@@ -113,3 +113,28 @@ def test_export(tmp_path, example_data):
         actual = tifffile.imread(str(filename))
         streamname = os.path.basename(filename).split('-')[0]
         assert_array_equal(actual, expected[streamname])
+
+
+@pytest.mark.parametrize("directory", ['', '/test-', '/scan_{start[uid]}-'])
+def test_directory_formatting(directory, example_data, tmp_path):
+    ''' runs a test of the file_prefix formatting.
+
+    ..note::
+
+        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of file_prefixes,
+        detectors and event_types. see `suitcase.utils.conftest` for more info.
+
+    '''
+    collector = example_data()
+    directory = str(tmp_path)+directory
+    artifacts = export(collector, directory)
+
+    for name, doc in collector:
+        if name == 'start':
+            templated_directory = directory.format(start=doc).partition('-')[0]
+
+    if artifacts:
+        unique_actual = set(str(artifact).rsplit('/', 1)[0].partition('-')[0]
+                            for artifact in artifacts['stream_data'])
+        assert unique_actual == set([templated_directory])

--- a/suitcase/tiff_series/tests/tests.py
+++ b/suitcase/tiff_series/tests/tests.py
@@ -127,7 +127,7 @@ def test_directory_formatting(directory, example_data, tmp_path):
 
     '''
     collector = example_data()
-    directory = str(tmp_path)+directory
+    directory = str(tmp_path) + directory
     artifacts = export(collector, directory)
 
     for name, doc in collector:

--- a/suitcase/tiff_stack/__init__.py
+++ b/suitcase/tiff_stack/__init__.py
@@ -207,7 +207,10 @@ class Serializer(event_model.DocumentRouter):
         else:
             self._start = doc  # record the start doc for later use
             if isinstance(self._directory, (str, Path)):
-                self._templated_directory = self._directory.format(**doc)
+                try:  # provided self._directory is a string
+                    self._templated_directory = self._directory.format(**doc)
+                except AttributeError:
+                    self._templated_directory = self._directory
                 self._manager = suitcase.utils.MultiFileManager(
                     self._templated_directory)
             else:

--- a/suitcase/tiff_stack/tests/conftest.py
+++ b/suitcase/tiff_stack/tests/conftest.py
@@ -1,4 +1,5 @@
 from bluesky.tests.conftest import RE  # noqa
 from ophyd.tests.conftest import hw  # noqa
 from suitcase.utils.tests.conftest import (  # noqa
-    example_data, generate_data, plan_type, detector_list, event_type)
+    example_data, generate_data, plan_type, detector_list, event_type,
+    file_prefix_list, directory_list)

--- a/suitcase/tiff_stack/tests/tests.py
+++ b/suitcase/tiff_stack/tests/tests.py
@@ -6,12 +6,12 @@ import tifffile
 
 
 def test_export(tmp_path, example_data):
-    ''' runs a test using the plan that is passed through to it.
+    '''Runs a test using the plan that is passed through to it.
 
     ..note::
 
         Due to the `example_data` `pytest.fixture` this will run multiple tests
-        each with a range of detectors and a range of event_types. see
+         each with a range of detectors and a range of event_types. See
         `suitcase.utils.conftest` for more info.
 
     '''
@@ -27,13 +27,13 @@ def test_export(tmp_path, example_data):
 
 
 def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
-    ''' runs a test of the file_prefix formatting.
+    '''Runs a test of the file_prefix formatting.
 
     ..note::
 
         Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
         this will run multiple tests each with a range of file_prefixes,
-        detectors and event_types. see `suitcase.utils.conftest` for more info.
+        detectors and event_types. See `suitcase.utils.conftest` for more info.
 
     '''
     collector = example_data()
@@ -51,13 +51,13 @@ def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
 
 
 def test_directory_formatting(directory_list, example_data, tmp_path):
-    ''' runs a test of the file_prefix formatting.
+    '''Runs a test of the directory formatting.
 
     ..note::
 
-        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
-        this will run multiple tests each with a range of file_prefixes,
-        detectors and event_types. see `suitcase.utils.conftest` for more info.
+        Due to the `directory_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of directories,
+        detectors and event_types. See `suitcase.utils.conftest` for more info.
 
     '''
     collector = example_data()
@@ -67,6 +67,7 @@ def test_directory_formatting(directory_list, example_data, tmp_path):
     for name, doc in collector:
         if name == 'start':
             templated_directory = directory.format(**doc).partition('-')[0]
+            break
 
     if artifacts:
         unique_actual = set(str(artifact).rsplit('/', 1)[0].partition('-')[0]

--- a/suitcase/tiff_stack/tests/tests.py
+++ b/suitcase/tiff_stack/tests/tests.py
@@ -6,13 +6,13 @@ import tifffile
 
 
 def test_export(tmp_path, example_data):
-    ''' runs a test using the plan that is passed through to it
+    ''' runs a test using the plan that is passed through to it.
 
     ..note::
 
-        Due to the `events_data` `pytest.fixture` this will run multiple tests
+        Due to the `example_data` `pytest.fixture` this will run multiple tests
         each with a range of detectors and a range of event_types. see
-        `suitcase.utils.conftest` for more info
+        `suitcase.utils.conftest` for more info.
 
     '''
 
@@ -24,3 +24,51 @@ def test_export(tmp_path, example_data):
         actual = tifffile.imread(str(filename))
         streamname = os.path.basename(filename).split('-')[0]
         assert_array_equal(actual, expected[streamname])
+
+
+def test_file_prefix_formatting(file_prefix_list, example_data, tmp_path):
+    ''' runs a test of the file_prefix formatting.
+
+    ..note::
+
+        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of file_prefixes,
+        detectors and event_types. see `suitcase.utils.conftest` for more info.
+
+    '''
+    collector = example_data()
+    file_prefix = file_prefix_list()
+    artifacts = export(collector, tmp_path, file_prefix=file_prefix)
+
+    for name, doc in collector:
+        if name == 'start':
+            templated_file_prefix = file_prefix.format(**doc).partition('-')[0]
+
+    if artifacts:
+        unique_actual = set(str(artifact).split('/')[-1].partition('-')[0]
+                            for artifact in artifacts['stream_data'])
+        assert unique_actual == set([templated_file_prefix])
+
+
+def test_directory_formatting(directory_list, example_data, tmp_path):
+    ''' runs a test of the file_prefix formatting.
+
+    ..note::
+
+        Due to the `file_prefix_list` and `example_data` `pytest.fixture`'s
+        this will run multiple tests each with a range of file_prefixes,
+        detectors and event_types. see `suitcase.utils.conftest` for more info.
+
+    '''
+    collector = example_data()
+    directory = str(tmp_path)+directory_list()
+    artifacts = export(collector, directory)
+
+    for name, doc in collector:
+        if name == 'start':
+            templated_directory = directory.format(**doc).partition('-')[0]
+
+    if artifacts:
+        unique_actual = set(str(artifact).rsplit('/', 1)[0].partition('-')[0]
+                            for artifact in artifacts['stream_data'])
+        assert unique_actual == set([templated_directory])


### PR DESCRIPTION
This would close issue #22 , as it adds the capability to template the directory path based on items from the start document.

Once it has been approved I will make similar changes to all the other suitcases.